### PR TITLE
int/builder: adds parent ref field to `Node` type, tests and example

### DIFF
--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -18,6 +18,21 @@ func linearize(n *Node) string {
 	return s
 }
 
+func breadcrumbs(n *Node) string {
+	s := ""
+	if n.Parent != nil {
+		s += breadcrumbs(n.Parent)
+	}
+	return s + "/" + n.Title
+}
+
+func dfs(n *Node, v func(*Node)) {
+	v(n)
+	for _, c := range n.Children {
+		dfs(c, v)
+	}
+}
+
 func check(tmp, path string) bool {
 	_, err := os.Stat(filepath.Join(tmp, path))
 	return err == nil
@@ -79,6 +94,26 @@ func TestBuild(t *testing.T) {
 | | | Getting Started
 | products`
 		if got := linearize(b.root3); got != expected {
+			t.Fatalf("expected:\n\n%s\n\ngot:\n%s", expected, got)
+		}
+	})
+
+	t.Run("breadcrumbs", func(t *testing.T) {
+		got := ""
+		dfs(b.root3, func(n *Node) {
+			got += "\n" + breadcrumbs(n)
+		})
+		expected := `
+/.
+/./career
+/./Docs
+/./Docs/ACME Bird Seed
+/./Docs/Download
+/./Docs/ACME Magnet
+/./Docs/tutorials
+/./Docs/tutorials/Getting Started
+/./products`
+		if got != expected {
 			t.Fatalf("expected:\n\n%s\n\ngot:\n%s", expected, got)
 		}
 	})

--- a/internal/builder/testdata/acme/docs/.kask/propagate/page.tmpl
+++ b/internal/builder/testdata/acme/docs/.kask/propagate/page.tmpl
@@ -1,12 +1,17 @@
-{{define "children"}}
+{{define "sitemap-item"}}
 <ul>
-  <a href="{{.Href}}">{{.Title}}</a>
+  {{if ne .Href ""}}<a href="{{.Href}}">{{.Title}}</a>{{else}}<span>{{.Title}}</span>{{end}}
   {{with .Children}}
   {{range .}}
-  <li>{{template "children" .}}</li>
+  <li>{{template "sitemap-item" .}}</li>
   {{end}}
   {{end}}
 </ul>
+{{end}}
+
+{{define "breadcrumb-item"}}
+{{with .Parent}}{{template "breadcrumb-item" .}}<span class="sep">/</span>{{end}}
+{{if ne .Href ""}}<a href="{{.Href}}">{{.Title}}</a>{{else}}<span>{{.Title}}</span>{{end}}
 {{end}}
 
 {{define "markdown-page"}}
@@ -37,7 +42,11 @@
 
   <body>
     <nav>
-      {{template "children" .Root}}
+      {{template "sitemap-item" .Root}}
+    </nav>
+
+    <nav id="breadcrumbs">
+      {{template "breadcrumb-item" .Node}}
     </nav>
 
     <aside aria-label="Table of Contents">


### PR DESCRIPTION
closes #7 