### PR TITLE
Refactor workers script

### DIFF
--- a/.workers/docs.sh
+++ b/.workers/docs.sh
@@ -2,5 +2,6 @@
 
 set -ve
 
+git fetch --tags --quiet
 make install
 ~/bin/kask build -in docs -out docs-build -domain / -v


### PR DESCRIPTION
To build the latest content (pointed by the ref of deployment) with the latest program, instead of the one registered as the latest version in go registry.